### PR TITLE
Remove statefulness of lastComputedValue for setTargetAtTime, fixes #1

### DIFF
--- a/lib/formulas.js
+++ b/lib/formulas.js
@@ -29,3 +29,5 @@ exports.exponentialApproach = function (t0, v0, v1, timeConstant, t) {
 exports.fuzzyEqual = function (lhs, rhs) {
   return Math.abs(lhs - rhs) < EPSILON;
 };
+
+exports.EPSILON = EPSILON;

--- a/lib/timeline.js
+++ b/lib/timeline.js
@@ -7,11 +7,6 @@ function Timeline (defaultValue) {
   this.events = [];
 
   this._value = defaultValue || 0;
-
-  // This is the value of this AudioParam we computed at the last call.
-  this._computedValue = defaultValue || 0;
-  // This is the value of this AudioParam at the last tick of the previous event.
-  this._lastComputedValue = defaultValue || 0;
 }
 
 Timeline.prototype.getEventCount = function () {
@@ -24,7 +19,7 @@ Timeline.prototype.value = function () {
 
 Timeline.prototype.setValue = function (value) {
   if (this.events.length === 0) {
-    this._computedValue = this._lastComputedValue = this._value = value;
+    this._value = value;
   }
 };
 
@@ -37,21 +32,19 @@ Timeline.prototype.getValue = function () {
 };
 
 Timeline.prototype.getValueAtTime = function (time) {
-  this._computedValue = this._getValueAtTimeHelper(time);
-  return this._computedValue;
+  return this._getValueAtTimeHelper(time);
 };
 
 Timeline.prototype._getValueAtTimeHelper = function (time) {
   var bailOut = false;
   var previous = null;
   var next = null;
+  var lastComputedValue = null; // Used for `setTargetAtTime` nodes
   var events = this.events;
   var e;
 
   for (var i = 0; !bailOut && i < events.length; i++) {
     if (F.fuzzyEqual(time, events[i].time)) {
-      this._lastComputedValue = this._computedValue;
-
       // Find the last event with the same time as `time`
       do {
         ++i;
@@ -61,7 +54,8 @@ Timeline.prototype._getValueAtTimeHelper = function (time) {
 
       // `setTargetAtTime` can be handled no matter what their next event is (if they have one)
       if (e.type === "setTargetAtTime") {
-        return e.exponentialApproach(this._lastComputedValue, time);
+        lastComputedValue = this._lastComputedValue(e);
+        return e.exponentialApproach(lastComputedValue, time);
       }
 
       // `setValueCurveAtTime` events can be handled no matter what their next event node is
@@ -99,7 +93,8 @@ Timeline.prototype._getValueAtTimeHelper = function (time) {
 
   // `setTargetAtTime` can be handled no matter what their next event is (if they have one)
   if (previous.type === "setTargetAtTime") {
-    return previous.exponentialApproach(this._lastComputedValue, time);
+    lastComputedValue = this._lastComputedValue(previous);
+    return previous.exponentialApproach(lastComputedValue, time);
   }
 
   // `setValueCurveAtTime` events can be handled no matter what their next event node is
@@ -243,6 +238,29 @@ Timeline.prototype._getPreviousEvent = function (time) {
   }
 
   return previous;
+};
+
+/**
+ * Calculates the previous value of the timeline, used for
+ * `setTargetAtTime` nodes. Takes an event, and returns
+ * the previous computed value for any sample taken during that
+ * exponential approach node.
+ */
+Timeline.prototype._lastComputedValue = function (event) {
+  // If equal times, return the value for the previous event, before
+  // the `setTargetAtTime` node.
+  var lastEvent = this._getPreviousEvent(event.time - F.EPSILON);
+
+  // If no event before the setTargetAtTime event, then return the
+  // built in value.
+  if (!lastEvent) {
+    return this._value;
+  }
+  // Otheriwse, return the value for the previous event, which should
+  // always be the last computed value (? I think?)
+  else {
+    return lastEvent.value;
+  }
 };
 
 Timeline.prototype.setValueAtTime = function (value, startTime) {

--- a/test/test.js
+++ b/test/test.js
@@ -114,14 +114,6 @@ describe("After Last Event", function () {
     timeline.setValue(50);
     timeline.setTargetAtTime(20, 1, 5);
 
-    // When using SetTargetValueAtTime, Timeline becomes stateful: the value for
-    // time t may depend on the time t-1, so we can't just query the value at a
-    // time and get the right value. We have to call GetValueAtTime for the
-    // previous times.
-    for (var i = 0; i < 9.99; i+= 0.01) {
-      timeline.getValueAtTime(i);
-    }
-
     expect(timeline.getValueAtTime(10)).to.be.equal(20 + (50-20) * (Math.exp(-9/5)));
   });
 });
@@ -197,4 +189,59 @@ it("exponential invalid previous zero value", function () {
   expect(timeline.getEventCount()).to.be.equal(0);
 
   timeline.exponentialRampToValueAtTime(1, 1);
+});
+
+it("setTargetAtTime works on subsequent calls, deterministic", function () {
+  var timeline = new Timeline(10);
+  timeline.setValueAtTime(500, 1);
+  timeline.setTargetAtTime(1000, 2, 0.5);
+
+  // v(t) = V1 + (V0 - V1) * exp(-(t - T0) / timeConstant)
+  expect(timeline.getValueAtTime(1)).to.be.equal(500);
+  expect(timeline.getValueAtTime(3)).to.be.closeTo(932.3323583, EPSILON);
+  expect(timeline.getValueAtTime(10)).to.be.closeTo(999.999943732, EPSILON);
+  expect(timeline.getValueAtTime(1)).to.be.equal(500);
+  expect(timeline.getValueAtTime(3)).to.be.closeTo(932.3323583, EPSILON);
+  expect(timeline.getValueAtTime(1)).to.be.equal(500);
+  expect(timeline.getValueAtTime(10)).to.be.closeTo(999.999943732, EPSILON);
+  expect(timeline.getValueAtTime(10)).to.be.closeTo(999.999943732, EPSILON);
+  expect(timeline.getValueAtTime(3)).to.be.closeTo(932.3323583, EPSILON);
+  expect(timeline.getValueAtTime(10)).to.be.closeTo(999.999943732, EPSILON);
+});
+
+it("setTargetAtTime works when first and last event, subsequent calls, deterministic", function () {
+  var timeline = new Timeline(10);
+  timeline.setTargetAtTime(1000, 2, 0.5);
+
+  // v(t) = V1 + (V0 - V1) * exp(-(t - T0) / timeConstant)
+  expect(timeline.getValueAtTime(2)).to.be.equal(10);
+  expect(timeline.getValueAtTime(4)).to.be.closeTo(981.8675175, EPSILON);
+  expect(timeline.getValueAtTime(4.95)).to.be.closeTo(997.2879496, EPSILON);
+
+  expect(timeline.getValueAtTime(4)).to.be.closeTo(981.8675175, EPSILON);
+  expect(timeline.getValueAtTime(4.95)).to.be.closeTo(997.2879496, EPSILON);
+  expect(timeline.getValueAtTime(2)).to.be.equal(10);
+  expect(timeline.getValueAtTime(2)).to.be.equal(10);
+  expect(timeline.getValueAtTime(2)).to.be.equal(10);
+  expect(timeline.getValueAtTime(4.95)).to.be.closeTo(997.2879496, EPSILON);
+});
+
+it("setTargetAtTime works when followed by another setTargetAtTime, subsequent calls, deterministic", function () {
+  var timeline = new Timeline(10);
+  timeline.setTargetAtTime(1000, 2, 0.5);
+  timeline.setTargetAtTime(2000, 5, 1);
+
+  // v(t) = V1 + (V0 - V1) * exp(-(t - T0) / timeConstant)
+  expect(timeline.getValueAtTime(2)).to.be.equal(10);
+  expect(timeline.getValueAtTime(4)).to.be.closeTo(981.8675175, EPSILON);
+  expect(timeline.getValueAtTime(4.95)).to.be.closeTo(997.2879496, EPSILON);
+  expect(timeline.getValueAtTime(10)).to.be.closeTo(1993.2620530, EPSILON);
+
+  expect(timeline.getValueAtTime(4)).to.be.closeTo(981.8675175, EPSILON);
+  expect(timeline.getValueAtTime(4.95)).to.be.closeTo(997.2879496, EPSILON);
+  expect(timeline.getValueAtTime(2)).to.be.equal(10);
+  expect(timeline.getValueAtTime(10)).to.be.closeTo(1993.2620530, EPSILON);
+  expect(timeline.getValueAtTime(2)).to.be.equal(10);
+  expect(timeline.getValueAtTime(2)).to.be.equal(10);
+  expect(timeline.getValueAtTime(10)).to.be.closeTo(1993.2620530, EPSILON);
 });


### PR DESCRIPTION
Due to Firefox's implementation always parsing time forward, linearly, the stateful implementation of `lastComputedValue` is fine, but for this, where we will requery different times as needed, it had a few issues, listed in #1.

When adding this fix, not only does it fix the state problem, but also more accurate results when plugging in values:

`v(t) = V1 + (V0 - V1) * exp(-(t - T0) / timeConstant)`

are the assumptions in `_lastComputedValue()` in this PR correct? That the `V0` in the above formula is from the previously computed value, being the previous event's `value`, or the inherit `value` (set by value setter) if no other events present? And when two `setTargetAtTime` events are scheduled, the second uses the previous' sTAT value as `V0`, even if that target was never closely reached (looks like that's how the implementation works).

@padenot any thoughts on this implementation?
